### PR TITLE
Fixed Crash When Connecting Coils

### DIFF
--- a/src/main/java/com/skidsdev/teslacoils/tile/ITeslaCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/tile/ITeslaCoil.java
@@ -49,7 +49,7 @@ public interface ITeslaCoil
 	 * 
 	 * @return The BlockPos of the TileEntity implementing ITeslaCoil
 	 */
-	public BlockPos getPos();
+	public BlockPos getCoilPos();
 	
 	/**
 	 * 

--- a/src/main/java/com/skidsdev/teslacoils/tile/TileEntityRelayCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/tile/TileEntityRelayCoil.java
@@ -230,12 +230,12 @@ public class TileEntityRelayCoil extends TileEntity implements ITickable, ITesla
 		
 		if (firstConnection != null)
 		{
-			BlockPos connectionPos = firstConnection.getPos();
+			BlockPos connectionPos = firstConnection.getCoilPos();
 			tag.setLong("FirstConnection", connectionPos.toLong());
 		}
 		if (secondConnection != null)
 		{
-			BlockPos connectionPos = secondConnection.getPos();
+			BlockPos connectionPos = secondConnection.getCoilPos();
 			tag.setLong("SecondConnection", connectionPos.toLong());
 		}
 		
@@ -287,7 +287,7 @@ public class TileEntityRelayCoil extends TileEntity implements ITickable, ITesla
 	}
 	
 	@Override
-	public BlockPos getPos()
+	public BlockPos getCoilPos()
 	{
 		return this.pos;
 	}

--- a/src/main/java/com/skidsdev/teslacoils/tile/TileEntityTeslaCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/tile/TileEntityTeslaCoil.java
@@ -314,7 +314,7 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 	}
 	
 	@Override
-	public BlockPos getPos()
+	public BlockPos getCoilPos()
 	{
 		return this.pos;
 	}
@@ -389,7 +389,7 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 		
 		for(int i = 0; i < connectedCoils.size(); i++)
 		{
-			BlockPos connectionPos = connectedCoils.get(i).getPos();
+			BlockPos connectionPos = connectedCoils.get(i).getCoilPos();
 			tag.setLong("Connection" + i, connectionPos.toLong());
 		}
 		

--- a/src/main/java/com/skidsdev/teslacoils/tile/tesr/TESRRelayCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/tile/tesr/TESRRelayCoil.java
@@ -64,7 +64,7 @@ public class TESRRelayCoil extends TileEntitySpecialRenderer<TileEntityRelayCoil
 
         buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_LMAP_COLOR);
         
-        BlockPos destination = new BlockPos(coil.getPos());
+        BlockPos destination = new BlockPos(coil.getCoilPos());
         Vector end = new Vector(destination.getX() + .5f, destination.getY() + .5f, destination.getZ() + .5f);
         
         int a = 128;

--- a/src/main/java/com/skidsdev/teslacoils/tile/tesr/TESRTeslaCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/tile/tesr/TESRTeslaCoil.java
@@ -56,7 +56,7 @@ public class TESRTeslaCoil extends TileEntitySpecialRenderer<TileEntityTeslaCoil
             
             for(ITeslaCoil tileEntity : te.connectedCoils)
             {
-	            BlockPos destination = new BlockPos(tileEntity.getPos());
+	            BlockPos destination = new BlockPos(tileEntity.getCoilPos());
 	            Vector end = new Vector(destination.getX() + .5f, destination.getY() + .5f, destination.getZ() + .5f);
 	            
 	            int a = 128;


### PR DESCRIPTION
While looking for a Tesla only transfer mod to test my block, I ran into the same linking issue as others.

getPos() is the culprit due to both ITeslaCoil and TileEntity having a method with the same name, parameters, and return.

It works in a development environment because they have the same name, but after the mod is compiled the getPos() in your tileentity becomes func_174877_v() but your interface still looks for getPos()

This fix just changes ITeslaCoil.getPos() to ITeslaCoil.getCoilPos() and makes the necessary updates.