### PR TITLE
Fixed TileEntityTeslaCoil Not Loading Its Saved Data

### DIFF
--- a/src/main/java/com/skidsdev/teslacoils/block/BlockTeslaCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/block/BlockTeslaCoil.java
@@ -42,7 +42,7 @@ public class BlockTeslaCoil extends BlockBaseCoil
 	@Override
 	public TileEntity createTileEntity(World worldIn, IBlockState state)
 	{
-		return new TileEntityTeslaCoil(((EnumCoilTier)state.getValue(COIL_TIER)).getTransferRate());
+		return new TileEntityTeslaCoil(((EnumCoilTier)state.getValue(COIL_TIER)));
 	}
 	
 	@Override

--- a/src/main/java/com/skidsdev/teslacoils/tile/TileEntityTeslaCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/tile/TileEntityTeslaCoil.java
@@ -43,15 +43,18 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 	@Nullable
 	private List<BlockPos> loadedTiles;
 	private TeslaContainerCoil container;
-	private long transferRate;
+	private BlockTeslaCoil.EnumCoilTier tier = BlockTeslaCoil.EnumCoilTier.BASIC;
 	
 	// Constructors
 	
-	public TileEntityTeslaCoil(long transferRate)
+	public TileEntityTeslaCoil()
+	{}
+	
+	public TileEntityTeslaCoil(BlockTeslaCoil.EnumCoilTier tier)
 	{
 		connectedCoils = new ArrayList<ITeslaCoil>();
-		container = new TeslaContainerCoil(transferRate);
-		this.transferRate = transferRate;
+		container = new TeslaContainerCoil(tier.getTransferRate());
+		this.tier = tier;
 	}
 	
 	// Overrides
@@ -62,6 +65,7 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 		super.readFromNBT(compound);
 		if(compound.hasKey("Connections")) loadedTiles = deserializeConnections((NBTTagCompound)compound.getTag("Connections"));
 		if(compound.hasKey("TeslaContainer")) container = new TeslaContainerCoil(compound.getTag("TeslaContainer"));
+		if(compound.hasKey("CoilTier")) tier = BlockTeslaCoil.EnumCoilTier.values()[compound.getInteger("CoilTier")];
 		connectedCoils = new ArrayList<ITeslaCoil>();
 	}
 	
@@ -73,6 +77,7 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 			compound.setTag("Connections", getConnectionNBT());
 		}
 		compound.setTag("TeslaContainer", container.serializeNBT());
+		compound.setInteger("CoilTier", tier.ordinal());
 		return super.writeToNBT(compound);
 	}
 
@@ -289,7 +294,7 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 					{
 						for(int i = 0; i < connectedConsumers.size() && container.getStoredPower() > 0; i++)
 						{
-							container.takePower(connectedConsumers.get(i).givePower(container.takePower(transferRate, true), false), false);
+							container.takePower(connectedConsumers.get(i).givePower(container.takePower(getTransferRate(), true), false), false);
 						}
 					}
 				}
@@ -328,7 +333,7 @@ public class TileEntityTeslaCoil extends TileEntity implements ITickable, ITesla
 	
 	public long getTransferRate()
 	{
-		return this.transferRate;
+		return this.tier.getTransferRate();
 	}
 	
 	// Private Methods


### PR DESCRIPTION
The saved data wasn't loading because TileEntities require a nullary constructor. Without it the TileEntity couldn't be created at the time of load, skipping readFromNBT.

For the transfer rate to be preserved it needed to be saved to the nbt, but I didn't do that directly, instead I saved the coil tier.
This was done so the changing of a tiers transfer rate updates any coils already in world to the new speed. As an added perk it enables you to add a way to do an in place upgrade to the next tier.

Line 297 was changed to use getTransferRate() to unify where that data comes from. This way if you decided to add an overclocker/transfer boost you only need to change this one spot for it to be applied.
