### PR TITLE
Localization Adjustments

### DIFF
--- a/src/main/java/com/skidsdev/teslacoils/block/BlockTeslaCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/block/BlockTeslaCoil.java
@@ -51,7 +51,7 @@ public class BlockTeslaCoil extends BlockBaseCoil
 		for(EnumCoilTier tier : EnumCoilTier.values())
 		{
 			ItemStack stack = new ItemStack(item, 1, 0);
-			ItemNBTHelper.setInt(stack, "CoilType", tier.ordinal());
+			ItemNBTHelper.setInt(stack, "CoilTier", tier.ordinal());
 			list.add(stack);
 		}
 	}

--- a/src/main/resources/assets/teslacoils/lang/en_US.lang
+++ b/src/main/resources/assets/teslacoils/lang/en_US.lang
@@ -1,5 +1,11 @@
 < en_US.lang - English localization file for the mod Tesla Coils >
-tile.teslacoils:blockTeslaCoil.name=Tesla Coil
+tile.teslacoils:blockTeslaCoil_basic.name=Basic Tesla Coil
+tile.teslacoils:blockTeslaCoil_advanced.name=Advanced Tesla Coil
+tile.teslacoils:blockTeslaCoil_industrial.name=Industrial Tesla Coil
+tile.teslacoils:blockTeslaCoil_creative.name=Creative Tesla Coil
 tile.teslacoils:blockRelayCoil.name=Relay Coil
-tile.teslacoils:blockTeslarract.name=Teslarract (WIP)
+tile.teslacoils:blockTeslarract_basic.name=Basic Teslarract
+tile.teslacoils:blockTeslarract_advanced.name=Advanced Teslarract
+tile.teslacoils:blockTeslarract_industrial.name=Industrial Teslarract
+tile.teslacoils:blockTeslarract_creative.name=Creative Teslarract
 item.teslacoils:itemTuningTool.name=Tuning Tool


### PR DESCRIPTION
This is all assumption based changes.

The block used CoilType to save to the nbt but the item used CoilTier to read it.
I figured CoilTier was the intended name.

Also added the missing keys to the localization file, with naming based on the tier names.