### PR TITLE
Change "pixelInc" to a "final".

### DIFF
--- a/src/main/java/com/skidsdev/teslacoils/block/BlockBaseCoil.java
+++ b/src/main/java/com/skidsdev/teslacoils/block/BlockBaseCoil.java
@@ -56,7 +56,7 @@ public abstract class BlockBaseCoil extends Block
 	{
 		EnumFacing facing = state.getValue(FACING);
 		
-		double pixelInc = 1.0 / 16.0;
+		final double pixelInc = 1.0 / 16.0;
 		
 		double startX = 0;
 		double startY = 0;


### PR DESCRIPTION
Setting it to 'final' will let the value be pre-computed to avoid overhead each time the function is called.